### PR TITLE
Downgrade of express version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "dotenv": "^8.2.0",
-    "express": "^4.17.7",
+    "express": "^4.17.1",
     "firebase-admin": "^8.12.1",
     "moment": "^2.26.0",
     "pg": "^7.18.2",


### PR DESCRIPTION
A ultima versão do ExpressJS no NPM é a 4.17.1.
https://www.npmjs.com/package/express
http://expressjs.com/en/changelog/4x.html